### PR TITLE
Опция sourceSuffixes для технологий использующих хелпер useFileList

### DIFF
--- a/lib/build-flow.js
+++ b/lib/build-flow.js
@@ -96,18 +96,14 @@ var BuildFlow = inherit( /** @lends BuildFlow.prototype */ {
     /**
      * Требует список файлов по суффиксу или суффиксам.
      * Например, .useFileList("js") добавит в аргументы билдеру список файлов с расширением js.
-     * Первым аргументом можно указать имя опции, в которой указаны суффиксы, тогда второй аргумент — дефолтное значение.
-     * @param {String} suffixesOptionName Имя опции для суффиксов.
+     * Значение по умолчанию можно переопределить параметром sourceSuffixes
      * @param {String|Array} defaultSuffixes Значение по умолчанию.
      * @returns {BuildFlow}
      */
-    useFileList: function(suffixesOptionName, defaultSuffixes) {
-        if (!defaultSuffixes) {
-            defaultSuffixes = suffixesOptionName;
-        }
+    useFileList: function(defaultSuffixes) {
         return this._copyAnd(function(buildFlow) {
             buildFlow._addUsage(
-                new BuildFlowLinkToFileList('filesTarget', '?.files', suffixesOptionName, defaultSuffixes)
+                new BuildFlowLinkToFileList('filesTarget', '?.files', defaultSuffixes)
             );
         });
     },
@@ -637,12 +633,12 @@ BuildFlowLinkToTargetSource = inherit(BuildFlowLinkToTargetResult, {
     }
 }),
 BuildFlowLinkToFileList = inherit(BuildFlowLinkToTargetResult, {
-    __constructor: function(targetOptionName, defaultTargetName, suffixesOptionName, defaultSuffixes) {
+    __constructor: function(targetOptionName, defaultTargetName, defaultSuffixes) {
         this._targetOptionName = targetOptionName;
         this._defaultTargetName = defaultTargetName;
         this._fieldName = '_' + targetOptionName;
         this._listName = '_list' + targetOptionName;
-        this._suffixesOptionName = suffixesOptionName;
+        this._suffixesOptionName = 'sourceSuffixes';
         this._defaultSuffixes = defaultSuffixes;
     },
     getTargetOptionName: function() {

--- a/techs/css-includes.js
+++ b/techs/css-includes.js
@@ -7,7 +7,7 @@
  * **Опции**
  *
  * * *String* **target** — Результирующий таргет. По умолчанию `?.css`.
- * * *String* **cssSources** — Суффиксы файлов для сборки. По умолчанию `css`.
+ * * *String* **sourceSuffixes** — Суффиксы файлов для сборки. По умолчанию `css`.
  * * *String* **filesTarget** — files-таргет, на основе которого получается список исходных файлов (его предоставляет технология `files`). По умолчанию — `?.files`.
  *
  * **Пример**
@@ -22,7 +22,7 @@ var inherit = require('inherit'),
 module.exports = require('../lib/build-flow').create()
     .name('css-includes')
     .target('target', '?.css')
-    .useFileList('cssSources', 'css')
+    .useFileList('css')
     .builder(function(cssFiles) {
         var node = this.node;
         return cssFiles.map(function(file) {


### PR DESCRIPTION
Теперь можно использовать css-includes для сборки и обычных стилей, и ieX, например вот так:

```
        require("enb/techs/css-includes"),

        [ require("enb/techs/css-includes"), {
            sourceSuffixes: 'ie6.css',
            target: '?.ie6.css'
        } ],
        [ require("enb/techs/css-includes"), {
            sourceSuffixes: 'ie7.css',
            target: '?.ie7.css'
        } ],
        [ require("enb/techs/css-includes"), {
            sourceSuffixes: 'ie8.css',
            target: '?.ie8.css'
        } ],
        [ require("enb/techs/css-includes"), {
            sourceSuffixes: 'ie9.css',
            target: '?.ie9.css'
        } ]
```
