### PR TITLE
При обработке css не резолвим пути, начинающиеся на "%"

### DIFF
--- a/lib/preprocess/css-preprocessor.js
+++ b/lib/preprocess/css-preprocessor.js
@@ -62,7 +62,7 @@ module.exports = inherit({
     },
 
     _resolveCssUrl: function(url, filename) {
-        if (url.substr(0, 5) === 'data:' || url.substr(0, 2) === '//' || ~url.indexOf('http://') || ~url.indexOf('https://')) {
+        if (url.substr(0, 5) === 'data:' || url.substr(0, 2) === '//' || ~url.indexOf('http://') || ~url.indexOf('https://') || ~url.indexOf('%')) {
             return url;
         } else {
             return this._buildCssRelativeUrl(url, filename);


### PR DESCRIPTION
Предлагаемый фикс для https://github.com/enb-make/enb/issues/23.

По хорошему нужно решить задачу определения, находится ли конструкция `url(...)` внутри другой конструкции `url(...)` (в моем случае – в заинлайненном svg). Но, поскольку эта задача труднореализуема простыми регекспами, предлагаю сейчас обойтись таким костылем.
