### PR TITLE
Exports ENB require

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,1 @@
+exports.require = require;


### PR DESCRIPTION
В bem-tools удобно создавать внешние технологии, использую библиотеки, с помощью которых строятся внутренние. Из-за того, что bem экспортирует свой require метод. Предлагаю сделать тоже самое.

``` js
var ENB = require(''enb),
    Vow = ENB.require('vow');
```

То есть, достаточно указывать в зависимостях только enb и иметь доступ к зависимым библиотекам.
