### PR TITLE
Для источника enb-специфичных файлов использовать директорию .enb/ вместо .bem/

### DIFF
--- a/lib/make.js
+++ b/lib/make.js
@@ -51,12 +51,18 @@ module.exports = inherit( /** @lends MakePlatform.prototype */ {
     init: function(cdir, mode) {
         this._mode = mode = mode || process.env.YENV || 'development';
 
+        this._cdir = cdir;
+
         var _this = this,
             projectName = path.basename(cdir),
-            makefilePath = cdir + '/.bem/enb-make.js',
-            personalMakefilePath = cdir + '/.bem/enb-make.personal.js';
+            configDir = this._getConfigDir(),
+            makefilePath = this._getMakeFile('make'),
+            personalMakefilePath = this._getMakeFile('make.personal');
 
-        this._cdir = cdir;
+        if (!makefilePath) {
+            throw new Error('Cannot find make configuration file.');
+        }
+
         this._projectName = projectName;
         this._logger = new Logger();
         this._buildState = {};
@@ -72,7 +78,7 @@ module.exports = inherit( /** @lends MakePlatform.prototype */ {
             return Vow.reject(err);
         }
 
-        if (fs.existsSync(personalMakefilePath)) {
+        if (personalMakefilePath) {
             delete require.cache[personalMakefilePath];
             require(personalMakefilePath)(projectConfig);
         }
@@ -92,7 +98,7 @@ module.exports = inherit( /** @lends MakePlatform.prototype */ {
             return task.cleanTargets([].slice.call(arguments, 1));
         });
 
-        var tmpDir = cdir + '/.bem/tmp';
+        var tmpDir = configDir + '/tmp';
 
         return vowFs.makeDir(tmpDir).then(function() {
             _this._cacheStorage = new CacheStorage(tmpDir + '/cache.js');
@@ -106,6 +112,47 @@ module.exports = inherit( /** @lends MakePlatform.prototype */ {
      */
     getDir: function() {
         return this._cdir;
+    },
+
+    /**
+     * Возвращает абсолютный путь к директории с конфигурационными файлами.
+     * В качестве директории ожидается либо .enb/, либо .bem/.
+     * @returns {string}
+     * @private
+     */
+    _getConfigDir: function() {
+        var cdir = this.getDir(),
+            possibleDirs = ['.enb', '.bem'],
+            configDir;
+        var isConfigDirExists = possibleDirs.some(function(dir) {
+            configDir = path.join(cdir, dir);
+            return fs.existsSync(configDir);
+        });
+        if (isConfigDirExists) {
+            return configDir;
+        } else {
+            throw new Error('Cannot find enb config directory. Should be either .enb/ or .bem/.');
+        }
+    },
+
+    /**
+     * Возвращает путь к указанному конфигу сборки.
+     * Если файлов make.js и make.personal.js не существует, то пробуем искать файлы с префиксом enb-.
+     * @param {String} file Название конфига (основной или персональный).
+     * @returns {String}
+     * @private
+     */
+    _getMakeFile: function(file) {
+        var configDir = this._getConfigDir(),
+            possiblePrefixes = ['enb-', ''],
+            makeFile;
+        var isMakeFileExists = possiblePrefixes.some(function(prefix) {
+            makeFile = path.join(configDir, prefix + file + '.js');
+            return fs.existsSync(makeFile);
+        });
+        if (isMakeFileExists) {
+            return makeFile;
+        }
     },
 
     /**


### PR DESCRIPTION
Хранить файлы enb в папке `.bem/` явный анахронизм. Предлагаю добавить возможность хранить enb-специфичные файлы в более логичном месте — папке `.enb/`.

Вместе с этим, было бы здорово именовать конфиги лаконичнее — `.enb/make.js`.
