### PR TITLE
Support `./` in target path

### DIFF
--- a/lib/make.js
+++ b/lib/make.js
@@ -314,6 +314,7 @@ module.exports = inherit( /** @lends MakePlatform.prototype */ {
      * @private
      */
     _resolveTarget: function(target, nodePaths) {
+        target = target.replace(/^(\.\/)+/g, '');
         for (var i = 0, l = nodePaths.length; i < l; i++) {
             var nodePath = nodePaths[i];
             if (target.indexOf(nodePath) === 0) {


### PR DESCRIPTION
Фикс исправляет следующее поведение:
- Если в конфиге прописать маску или таргет, которые начинаются с `./`, то для `./node_modules/.bin/enb make pages/index/index.html` не найдётся таргета.
- И наоборот, если в конфиге прописать без `./`, то для `./node_modules/.bin/enb make ./pages/index/index.html` тоже не наёдётся таргета.
