### PR TITLE
технология ie7.css должна использовать файлы по маске ie.css'

### DIFF
--- a/techs/css-ie7.js
+++ b/techs/css-ie7.js
@@ -22,5 +22,5 @@ var inherit = require('inherit'),
 module.exports = require('./css').buildFlow()
     .name('css-ie7')
     .target('target', '?.ie7.css')
-    .useFileList(['css', 'ie7.css'])
+    .useFileList(['css', 'ie.css', 'ie7.css'])
     .createTech();

--- a/test/fixtures/sample-project-result/page/page.ie.css
+++ b/test/fixtures/sample-project-result/page/page.ie.css
@@ -1,0 +1,13 @@
+/* ../blocks/page/page.css: begin */ /**/
+    .page {
+        background: #000 url(../blocks/page/1.png);
+    }
+    
+/* ../blocks/page/page.css: end */ /**/
+
+/* ../blocks/page/page.ie.css: begin */ /**/
+    .page {
+        background: #222 url(../blocks/page/1.png);
+    }
+    
+/* ../blocks/page/page.ie.css: end */ /**/

--- a/test/fixtures/sample-project-result/page/page.ie7.css
+++ b/test/fixtures/sample-project-result/page/page.ie7.css
@@ -1,0 +1,20 @@
+/* ../blocks/page/page.css: begin */ /**/
+    .page {
+        background: #000 url(../blocks/page/1.png);
+    }
+    
+/* ../blocks/page/page.css: end */ /**/
+
+/* ../blocks/page/page.ie.css: begin */ /**/
+    .page {
+        background: #222 url(../blocks/page/1.png);
+    }
+    
+/* ../blocks/page/page.ie.css: end */ /**/
+
+/* ../blocks/page/page.ie7.css: begin */ /**/
+    .page {
+        background: #555 url(../blocks/page/1.png);
+    }
+    
+/* ../blocks/page/page.ie7.css: end */ /**/

--- a/test/fixtures/sample-project/.bem/enb-make.js
+++ b/test/fixtures/sample-project/.bem/enb-make.js
@@ -19,10 +19,12 @@ module.exports = function(config) {
             [ require(ENB_ROOT + "techs/i18n-lang-js"), { lang: "{lang}" } ],
             [ require(ENB_ROOT + "techs/js-i18n"), { lang: "{lang}" } ],
             require(ENB_ROOT + "techs/css"),
+            require(ENB_ROOT + "techs/css-ie"),
+            require(ENB_ROOT + "techs/css-ie7"),
             require(ENB_ROOT + "techs/priv-js"),
             [ require(ENB_ROOT + "techs/priv-js-i18n"), { lang: "{lang}" } ]
         ]);
-        nodeConfig.addTargets(["?.html", "?.en.html", "?.{lang}.js", "?.css", "?.{lang}.priv.js", "?.old.deps.js"]);
+        nodeConfig.addTargets(["?.html", "?.en.html", "?.{lang}.js", "?.css", "?.ie.css", "?.ie7.css", "?.{lang}.priv.js", "?.old.deps.js"]);
 
         function getLevels() {
             return [

--- a/test/fixtures/sample-project/blocks/page/page.ie.css
+++ b/test/fixtures/sample-project/blocks/page/page.ie.css
@@ -1,0 +1,3 @@
+.page {
+    background: #222 url(1.png);
+}

--- a/test/fixtures/sample-project/blocks/page/page.ie7.css
+++ b/test/fixtures/sample-project/blocks/page/page.ie7.css
@@ -1,0 +1,3 @@
+.page {
+    background: #555 url(1.png);
+}


### PR DESCRIPTION
результаты сборки целей *.ie{6,7,8,9}.css должны включать в себя содержимое файлов *.ie.css

если это ожидаемое поведение не только для меня, могу добавить по аналогии правки по остальным технологиям
