### PR TITLE
fixed logic of directory suffix making

### DIFF
--- a/lib/levels/level.js
+++ b/lib/levels/level.js
@@ -92,11 +92,10 @@ module.exports = inherit({
             }
         }
         if (processFile) {
-            var suffix = stat.isDirectory() ? baseNameParts.pop() : baseNameParts.slice(1).join('.'),
-                fileInfo = {
+            var fileInfo = {
                     name: baseName,
                     fullname: filename,
-                    suffix: suffix,
+                    suffix: baseNameParts.slice(1).join('.'),
                     mtime: stat.mtime.getTime(),
                     isDirectory: stat.isDirectory()
                 };


### PR DESCRIPTION
## Даешь честные суффиксы!

Решили разделить переводы по папкам, чтобы переводы привов лежали в папке `b-block.priv.i18n` и переводы фронтэнда (js) в `b-block.i18n`

Наша структура
- b-block.priv.i18n // папка с переводами
- b-block.i18n  // папка с переводами
- b-block.priv.js
- b-block.js
- b-block.css

в соответствующих технологиях пишем 
- `.useDirList('priv.i18n')`
  функция `build`получает пустой массив
- `.useDirList('i18n')`
  функция `build`получает массив в котором находятся `priv.i18n` и `i18n` как будто писали `.useDirList(['priv.i18n', 'i18n'])`
