### PR TITLE
Fixed `require` for `node-js` tech

### DIFF
--- a/README.md
+++ b/README.md
@@ -1429,7 +1429,7 @@ nodeConfig.addTech([ require('enb/techs/levels'), {
 node-js
 -------
 
-Склеивает `vanilla.js` и `node.js`-файлы по deps'ам, сохраняет в виде `?.node.js`.
+Собирает *vanilla.js* и *node.js*-файлы по deps'ам с помощью `require`, сохраняет в виде `?.node.js`.
 
 **Опции**
 

--- a/techs/node-js.js
+++ b/techs/node-js.js
@@ -2,7 +2,7 @@
  * node-js
  * =======
  *
- * Склеивает *vanilla.js* и *node.js*-файлы по deps'ам, сохраняет в виде `?.node.js`.
+ * Собирает *vanilla.js* и *node.js*-файлы по deps'ам с помощью `require`, сохраняет в виде `?.node.js`.
  *
  * **Опции**
  *


### PR DESCRIPTION
Исправляет ситуацию, когда внутри `*.node.js`-файлов исользуются `require`.
