### PR TITLE
Fix readme code

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ ENB_FILE_LIMIT=100 ./node_modules/.bin/enb make
 5. Проверить, что ENB работает. Команда `node_modules/.bin/enb make` должна выполниться без ошибок.
 6. 
   Теперь нужно настроить ноды. Для примера, я приведу вариант настройки ноды `pages/index`.
+
   ```javascript
   module.exports = function(config) {
       config.node('pages/index', function(nodeConfig) {
@@ -143,6 +144,7 @@ ENB_FILE_LIMIT=100 ./node_modules/.bin/enb make
   Так объявляется нода в рамках make-платформы. В данный момент она не настроена, а лишь объявлена.
 7. 
   Объявим таргеты, которые надо собрать для ноды:
+
   ```javascript
   module.exports = function(config) {
       config.node('pages/index', function(nodeConfig) {


### PR DESCRIPTION
Добавил пару пробелов в README.MD, чтобы примеры кода отображались правильно:

![2014-01-10 12 12 46](https://f.cloud.github.com/assets/1527181/1885502/1b9329b8-79cf-11e3-8aa3-e834429572e2.png)
&darr;
![2014-01-10 12 15 04](https://f.cloud.github.com/assets/1527181/1885507/63482416-79cf-11e3-93e0-ad85b6a7f064.png)

и

![2014-01-10 12 12 56](https://f.cloud.github.com/assets/1527181/1885504/2928f102-79cf-11e3-87ee-174c27c24cc8.png)
&darr;
![2014-01-10 12 15 10](https://f.cloud.github.com/assets/1527181/1885509/67f60f78-79cf-11e3-9db4-ba32ad8e47ec.png)
