### PR TITLE
Fix empty keys compilation for i18n's processing

### DIFF
--- a/exlib/tanker.js
+++ b/exlib/tanker.js
@@ -53,6 +53,10 @@ var parseXml = exports.parseXml = function (xml, cb) {
 
         var code = expandNodes(toCommonNodes(nodes), jsExpander);
 
+        if (!code.length) {
+            return '\'\'';
+        }
+
         return code.length === 1 &&
             (code[0].charAt(0) === QUOTE_CHAR || code[0].charAt(0) === SINGLE_QUOTE_CHAR ) ?
                 code[0] : 'function (params) { return ' + code.join(' + ') + ' }';


### PR DESCRIPTION
Port fix from bem/bem-bl#440

Right now empty keys, e.g. `""`, are translated to JS code

``` javascript
function() { return; }
```

which is not correct.
