### PR TITLE
Fixed bug with `resolvePath` of `project-config`

### DIFF
--- a/lib/config/project-config.js
+++ b/lib/config/project-config.js
@@ -8,6 +8,7 @@ var TaskConfig = require('./task-config');
 var ModeConfig = require('./mode-config');
 var inherit = require('inherit');
 var dirGlob = require('../fs/dir-glob');
+var path = require('path');
 
 /**
  * Инстанции класса ProjectConfig передаются в enb-make-файлы.
@@ -72,13 +73,13 @@ module.exports = inherit( /** @lends ProjectConfig.prototype */ {
      * @param {String|Object} path
      * @returns {String}
      */
-    resolvePath: function (path) {
-        if (path) {
-            if (typeof path === 'string') {
-                return this._rootPath + '/' + path;
+    resolvePath: function (sourcePath) {
+        if (sourcePath) {
+            if (typeof sourcePath === 'string') {
+                return path.resolve(this._rootPath, sourcePath);
             } else {
-                path.path = this._rootPath + '/' + path.path;
-                return path;
+                sourcePath.path = path.resolve(this._rootPath, sourcePath.path);
+                return sourcePath;
             }
         } else {
             return this._rootPath;


### PR DESCRIPTION
Метод `resolvePath` из модуля `project-config.js` изменяет переданный ему объект.

Например, если мы напишем что-то подобное в конфиге `make.js`:

``` js
var commonLevels = [
        { path: 'libs/bem-bl/blocks-common', check: false },
        'common.blocks'
    ];

function getCommonLevels(config) {
    return commonLevels.map(function(level) {
        return config.resolvePath(level);
    });
}
```

то получим вот такую ошибку:

``` console
Error: ENAMETOOLONG, name too long '/Users/blond/Projects/bem-components/
/Users/blond/Projects/bem-components//Users/blond/Projects/bem-components/
/Users/blond/Projects/bem-components//Users/blond/Projects/bem-components

...

//Users/blond/Projects/bem-components/libs/bem-bl/blocks-common'
    at Object.fs.readdirSync (fs.js:654:18)
    at module.exports.inherit.load (/Users/blond/Projects/bem-components/node_modules/enb/lib/levels/level.js:221:28)
    at /Users/blond/Projects/bem-components/node_modules/enb/techs/levels.js:91:38
    at Array.map (native)
    at /Users/blond/Projects/bem-components/node_modules/enb/techs/levels.js:90:46
    at Object.cb [as oncomplete] (fs.js:168:19)
make: *** [build] Error 1
```
