### PR TITLE
add-dir-option: add dir option to make, fix relative problems

### DIFF
--- a/lib/cli/make.js
+++ b/lib/cli/make.js
@@ -4,19 +4,20 @@
  *
  * Этот файл запускает сборку из командной строки.
  */
-var cdir = process.cwd();
 var MakePlatform = require('../make');
 var makePlatform = new MakePlatform();
+var path = require('path');
 
 module.exports = function (program) {
     program.command('make')
         .option('-n, --no-cache', 'drop cache before running make')
+        .option('-d, --dir <dir>', 'custom project root', process.cwd())
         .option('--graph', 'draws build graph')
         .description('build specified targets')
         .action(function () {
             var args = program.args.slice(0);
             var cmd = args.pop();
-            makePlatform.init(cdir).then((function () {
+            makePlatform.init(path.resolve(cmd.dir)).then((function () {
                 if (cmd.cache) {
                     makePlatform.loadCache();
                 }

--- a/lib/node.js
+++ b/lib/node.js
@@ -281,7 +281,7 @@ module.exports = inherit( /** @lends Node.prototype */ {
      * @returns {String}
      */
     relativePath: function (filename) {
-        var res = path.relative(this._path, filename);
+        var res = path.relative(path.join(this._root, this._path), filename);
         if (res.charAt(0) !== '.') {
             res = './' + res;
         }

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "unit-test": "mocha -u bdd -R spec --recursive test/lib",
     "func-test": "npm run-script bh-sym && npm run-script build-sample-proj && mocha -u bdd -R spec --recursive test/func",
     "bh-sym": "mkdir -p node_modules/bh/node_modules && rm -f node_modules/bh/node_modules/enb && ln -s ../../.. node_modules/bh/node_modules/enb",
-    "build-sample-proj": "cd test/fixtures/sample-project && ../../../bin/enb make -n --graph",
+    "build-sample-proj": "./bin/enb make -n --graph --dir test/fixtures/sample-project",
     "check-style": "jscs -c node_modules/enb-validate-code/jscs.json lib exlib techs test"
   }
 }

--- a/techs/levels.js
+++ b/techs/levels.js
@@ -32,6 +32,7 @@ var Levels = require('../lib/levels/levels');
 var Vow = require('vow');
 var VowFs = require('../lib/fs/async-fs');
 var inherit = require('inherit');
+var path = require('path');
 
 module.exports = inherit(require('../lib/tech/base-tech'), {
     getName: function () {
@@ -81,7 +82,7 @@ module.exports = inherit(require('../lib/tech/base-tech'), {
             levelList.push(this.node.buildState[levelKey]);
         }
 
-        return VowFs.listDir(_this.node.getPath())
+        return VowFs.listDir(path.join(_this.node.getRootDir(), _this.node.getPath()))
             .then(function (listDir) {
                 return _this._sublevelDirectories.filter(function (path) {
                     return listDir.indexOf(path) !== -1;


### PR DESCRIPTION
Добавил для enb make опцию --dir чтобы можно было запускать enb не только из корня проекта, по умолчанию она равна cwd. В связи с этим было найдено два места где не учитывался cwd, это было исправлено
