### PR TITLE
Replace backslash to normal slash in relative paths

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -282,6 +282,9 @@ module.exports = inherit( /** @lends Node.prototype */ {
      */
     relativePath: function (filename) {
         var res = path.relative(path.join(this._root, this._path), filename);
+        if (~res.indexOf('\\')) {
+            res = res.replace(/\\/g, '/');
+        }
         if (res.charAt(0) !== '.') {
             res = './' + res;
         }


### PR DESCRIPTION
По мотивам https://github.com/enb-make/bh/pull/25.
Под виндой в сгенерированных файлах слеши в путях развернуты в другую сторону.
В CSS, например, ломаются URL, а BH собирает BEMHTML файл со сломанным require.

``` css
.block {
    background-image: url("..\..\blocks.desktop\block\block.png");
}
```
