### PR TITLE
fix make.initNode

### DIFF
--- a/lib/make.js
+++ b/lib/make.js
@@ -296,12 +296,13 @@ module.exports = inherit( /** @lends MakePlatform.prototype */ {
     initNode: function (nodePath) {
         if (!this._nodeInitPromises[nodePath]) {
             var _this = this;
+            var cdir = this.getDir();
             var nodeConfig = this._projectConfig.getNodeConfig(nodePath);
             var node = new Node(nodePath, this, this._cache);
             node.setLogger(this._logger.subLogger(nodePath));
             node.setBuildGraph(this._graph);
             this._nodes[nodePath] = node;
-            this._nodeInitPromises[nodePath] = vowFs.makeDir(nodePath)
+            this._nodeInitPromises[nodePath] = vowFs.makeDir(path.join(cdir, nodePath))
                 .then(function () {
                     return Vow.when(nodeConfig.exec());
                 })


### PR DESCRIPTION
Не учитывалась текущия директория проекта `cdir`.
