### PR TITLE
Added support for hash url

### DIFF
--- a/lib/preprocess/css-preprocessor.js
+++ b/lib/preprocess/css-preprocessor.js
@@ -70,6 +70,7 @@ module.exports = inherit({
     _resolveCssUrl: function (url, filename) {
         if (url.substr(0, 5) === 'data:' ||
             url.substr(0, 2) === '//' ||
+            url.substr(0, 1) === '#' ||
             ~url.indexOf('http://') ||
             ~url.indexOf('https://')
         ) {


### PR DESCRIPTION
The `enb/techs/css` technology builds relative url from source hash url.
The next css (with hash url)
```css
.button_theme_pseudo
{
  background: url(#); /* For IE8 */
}
```
is builded in
```css
.button_theme_pseudo
{
  background: url(../../../libs/islands-components/desktop.blocks/button/_theme/#); /* For IE8 */
}
```
Expected result is original url without changes.