### PR TITLE
Save cache key-value by key-value to reduce memory footprint

### DIFF
--- a/lib/cache/cache-storage.js
+++ b/lib/cache/cache-storage.js
@@ -4,6 +4,7 @@
  */
 var fs = require('fs');
 var dropRequireCache = require('../fs/drop-require-cache');
+var Vow = require('vow');
 /**
  * CacheStorage — хранилище для кэша.
  * @name CacheStorage
@@ -40,6 +41,32 @@ CacheStorage.prototype = {
     save: function () {
         fs.writeFileSync(this._filename, 'module.exports = ' + JSON.stringify(this._data) + ';', 'utf8');
         this._mtime = fs.statSync(this._filename).mtime.getTime();
+    },
+
+    /**
+     * Сохраняет кэш в файл асинхронно.
+     */
+    saveAsync: function () {
+        var _this = this;
+        var promise = Vow.promise();
+        var stream = fs.createWriteStream(this._filename)
+            .on('error', function (err) {
+                promise.reject(err);
+            });
+
+        // Делаем stringify() на каждый объект в кеше чтобы уменьшить потребление памяти -
+        // stringify() на больших кешах может отъедать сотни МБ.
+        stream.write('module.exports = {');
+        Object.keys(this._data).forEach(function (key) {
+            stream.write('"' + key + '":' + JSON.stringify(_this._data[key]) + ',');
+        });
+
+        stream.end('};', function () {
+            _this._mtime = fs.statSync(_this._filename).mtime.getTime();
+            promise.fulfill();
+        });
+
+        return promise;
     },
 
     /**

--- a/lib/cli/make.js
+++ b/lib/cli/make.js
@@ -7,6 +7,7 @@
 var MakePlatform = require('../make');
 var makePlatform = new MakePlatform();
 var path = require('path');
+var Vow = require('vow');
 
 module.exports = function (program) {
     program.command('make')
@@ -29,8 +30,7 @@ module.exports = function (program) {
                     if (cmd.graph) {
                         console.log(makePlatform.getBuildGraph().render());
                     }
-                    makePlatform.saveCache();
-                    return makePlatform.destruct();
+                    return Vow.when(makePlatform.saveCache(), makePlatform.destruct.bind(makePlatform));
                 });
             }))
             .then(null, function (err) {

--- a/lib/make.js
+++ b/lib/make.js
@@ -212,10 +212,22 @@ module.exports = inherit( /** @lends MakePlatform.prototype */ {
      * Сохраняет кэш во временную папку.
      */
     saveCache: function () {
+        this._setCacheAttrs();
+        return this._cacheStorage.save();
+    },
+
+    /**
+     * Сохраняет кэш во временную папку асинхронно.
+     */
+    saveCacheAsync: function () {
+        this._setCacheAttrs();
+        return this._cacheStorage.saveAsync();
+    },
+
+    _setCacheAttrs: function () {
         this._cacheStorage.set(':make', 'mode', this._mode);
         this._cacheStorage.set(':make', 'version', require('../package.json').version);
         this._cacheStorage.set(':make', 'makefiles', this._getMakefileMTimes());
-        this._cacheStorage.save();
     },
 
     /**


### PR DESCRIPTION
На одном из наших проектов мы столкнулись с тем, что сборка падает по превышению лимита памяти в v8. Выяснилось что сама сборка проходит и падает во время сохранения кеша. Сериализация объекта кеша в нашем случае требует сотни мегабайт (файл кеша получается около 300МБ).

В этом PR кеш сохраняется кусками, что сильно уменьшает потребление памяти.