### PR TITLE
`hash-url` сломал стандартное поведение `enb-sass`

### DIFF
--- a/lib/preprocess/css-preprocessor.js
+++ b/lib/preprocess/css-preprocessor.js
@@ -70,7 +70,7 @@ module.exports = inherit({
     _resolveCssUrl: function (url, filename) {
         if (url.substr(0, 5) === 'data:' ||
             url.substr(0, 2) === '//' ||
-            url.substr(0, 1) === '#' ||
+            (url.substr(0, 1) === '#' && url.substr(0, 3) !== '#{$') || // В SASS переменные вставляются в строку вот так: "#{$var}string"
             ~url.indexOf('http://') ||
             ~url.indexOf('https://')
         ) {

--- a/lib/preprocess/css-preprocessor.js
+++ b/lib/preprocess/css-preprocessor.js
@@ -70,7 +70,8 @@ module.exports = inherit({
     _resolveCssUrl: function (url, filename) {
         if (url.substr(0, 5) === 'data:' ||
             url.substr(0, 2) === '//' ||
-            (url.substr(0, 1) === '#' && url.substr(0, 3) !== '#{$') || // В SASS переменные вставляются в строку вот так: "#{$var}string"
+            // В SASS переменные вставляются в строку вот так: "#{$var}string"
+            (url.substr(0, 1) === '#' && url.substr(0, 3) !== '#{$') ||
             ~url.indexOf('http://') ||
             ~url.indexOf('https://')
         ) {


### PR DESCRIPTION
Проблема в том, что если в `url()` будет значение вида `#{$key}.svg`, то сломается стандартное поведение технологии `enb-sass` и вместо ожидаемого `ЗНАЧЕНИЕ_ПЕРЕМЕННОЙ.svg`, получим полный путь до файла.

@blond Андрей, по понятым причинам я не выложить сюда ссылку на код `enb-sass`, но скажу лишь что переделать механику компиляции не получится, мы всегда должны понимать файл, в котором обрабатываем урлы, а делать сначала компиляцию sass → css, потом замену урлов для каждого файла — очень долго.

Все поехало после 
https://github.com/enb-make/enb/commit/a3f9752478a71ca2c224523045910831d0214e95