### PR TITLE
real tech inheritance

### DIFF
--- a/lib/build-flow.js
+++ b/lib/build-flow.js
@@ -6,6 +6,7 @@
 var inherit = require('inherit');
 var Vow = require('vow');
 var vowFs = require('./fs/async-fs');
+var baseTech = require('./tech/base-tech');
 
 /**
  * BuildFlow — это хэлпер для упрощения создания полностью настраиваемых технологий.
@@ -38,6 +39,7 @@ var BuildFlow = inherit( /** @lends BuildFlow.prototype */ {
         this._staticMethods = {};
         this._deprecationNotice = null;
         this._optionAliases = {};
+        this._inheritTech = baseTech;
         this._prepareFunc = function () {};
         this._buildFunc = function () {
             throw new Error('You should declare build function using "build" method of BuildFlow.');
@@ -386,6 +388,7 @@ var BuildFlow = inherit( /** @lends BuildFlow.prototype */ {
         result._cacheSaver = this._cacheSaver;
         result._prepareFunc = this._prepareFunc;
         result._deprecationNotice = this._deprecationNotice;
+        result._inheritTech = this._inheritTech;
         var options = this._options;
         Object.keys(options).forEach(function (optName) {
             result._options[optName] = options[optName];
@@ -504,7 +507,7 @@ var BuildFlow = inherit( /** @lends BuildFlow.prototype */ {
      * Создает технологию.
      * @returns {Tech}
      */
-    createTech: function (inheritTech) {
+    createTech: function () {
         var name = this._name;
         var targetOptionName = this._targetOptionName;
         var defaultTargetName = this._defaultTargetName;
@@ -686,7 +689,8 @@ var BuildFlow = inherit( /** @lends BuildFlow.prototype */ {
         /**
          * Результирующая технология, которая строится на основе инстанции BuildFlow.
          */
-        var resultTech = inherit(inheritTech || require('./tech/base-tech'), resultTechMethods, staticMethods);
+
+        var resultTech = inherit(this._inheritTech, resultTechMethods, staticMethods);
         var currentBuildFlow = this;
         /**
          * Каждому классу технологий добавляем метод buildFlow, чтобы вернуть инстанцию BuildFlow, с помощью которой
@@ -694,6 +698,7 @@ var BuildFlow = inherit( /** @lends BuildFlow.prototype */ {
          * @returns {BuildFlow}
          */
         resultTech.buildFlow = function () {
+            currentBuildFlow._inheritTech = resultTech;
             return currentBuildFlow;
         };
         return resultTech;

--- a/lib/build-flow.js
+++ b/lib/build-flow.js
@@ -504,7 +504,7 @@ var BuildFlow = inherit( /** @lends BuildFlow.prototype */ {
      * Создает технологию.
      * @returns {Tech}
      */
-    createTech: function () {
+    createTech: function (inheritTech) {
         var name = this._name;
         var targetOptionName = this._targetOptionName;
         var defaultTargetName = this._defaultTargetName;
@@ -574,7 +574,7 @@ var BuildFlow = inherit( /** @lends BuildFlow.prototype */ {
             },
             _isRebuildRequired: function () {
                 var cache = this.node.getNodeCache(this._target);
-                if (cacheValidator.call(this, cache)) {
+                if (this.cacheValidator(cache)) {
                     return true;
                 }
                 if (cache.needRebuildFile('target', this.node.resolvePath(this._target))) {
@@ -587,23 +587,28 @@ var BuildFlow = inherit( /** @lends BuildFlow.prototype */ {
                 }
                 return false;
             },
+            cacheValidator: cacheValidator,
             _saveCache: function () {
                 var cache = this.node.getNodeCache(this._target);
                 cache.cacheFileInfo('target', this.node.resolvePath(this._target));
                 for (var i = 0, l = usages.length; i < l; i++) {
                     usages[i].saveCache(this, this.node, cache);
                 }
-                cacheSaver.call(this, cache);
+                this.cacheSaver(cache);
             },
+            cacheSaver: cacheSaver,
             _getBuildResult: function () {
-                return buildFunc.apply(this, arguments);
+                return this.buildFunc.apply(this, arguments);
             },
+            buildFunc: buildFunc,
             _saveBuildResult: function () {
-                return saveFunc.apply(this, arguments);
+                return this.saveFunc.apply(this, arguments);
             },
+            saveFunc: saveFunc,
             _wrapBuildResult: function () {
-                return wrapFunc.apply(this, arguments);
+                return this.wrapFunc.apply(this, arguments);
             },
+            wrapFunc: wrapFunc,
             _joinFiles: function (files, wrapper) {
                 var _this = this;
                 return Vow.all(files.map(function (fileInfo) {
@@ -635,8 +640,9 @@ var BuildFlow = inherit( /** @lends BuildFlow.prototype */ {
                 this._buildResult = value;
             },
             _prepare: function () {
-                return preparer.call(this);
+                return this.preparer();
             },
+            preparer: preparer,
             build: function () {
                 var _this = this;
                 var node = this.node;
@@ -680,7 +686,7 @@ var BuildFlow = inherit( /** @lends BuildFlow.prototype */ {
         /**
          * Результирующая технология, которая строится на основе инстанции BuildFlow.
          */
-        var resultTech = inherit(require('./tech/base-tech'), resultTechMethods, staticMethods);
+        var resultTech = inherit(inheritTech || require('./tech/base-tech'), resultTechMethods, staticMethods);
         var currentBuildFlow = this;
         /**
          * Каждому классу технологий добавляем метод buildFlow, чтобы вернуть инстанцию BuildFlow, с помощью которой


### PR DESCRIPTION
Из-за `_copyAnd` красивое решение не придумалось, так что насчет вот такого:
```js
module.exports = require('someTech').buildFlow()
    .builder(function() {
        return this.__base.apply(this, arguments);
    })
    .methods({
        append: function() {
            return this.__base.apply(this, arguments)
        }
    })
    .createTech(require('someTech'));
```
?

UPD
таки придумалось, в конце не надо снова прокидывать ту же технологию.