### PR TITLE
Ignored async-fs in coverage

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,6 +87,8 @@
       "lib/**/*.js",
       "-e",
       "node_modules/**",
+      "-e",
+      "lib/fs/async-fs.js",
       "-t",
       "test/**",
       "-a",


### PR DESCRIPTION
Resolved #277 

Предлагаю пока просто игнорировать `async-fs` при посчёте `coverage`. Плюс попробовать воспроизвести проблему и завести баг в `unit-coverage`.