### PR TITLE
Up enb-source-map to version with spaces problem fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "vow": "~0.3.9",
     "vow-fs": "~0.2.2",
     "worker-farm": "1.3.1",
-    "enb-source-map": "1.7.0"
+    "enb-source-map": "1.7.1"
   },
   "devDependencies": {
     "bh": "0.1.14",


### PR DESCRIPTION
Depends on https://github.com/enb-make/enb-source-map/pull/6