### PR TITLE
Update make.js

### DIFF
--- a/lib/api/make.js
+++ b/lib/api/make.js
@@ -21,7 +21,7 @@ module.exports = function (targets, options) {
     targets = targets || [];
     options = options || {};
 
-    if (arguments.length === 1 && typeof targets === 'object') {
+    if (arguments.length === 1 && !Array.isArray(targets)) {
         options = targets;
         targets = [];
     }


### PR DESCRIPTION
Check of "first argument is not array" corrected. This case was wrong and .do not work correctly. I think this case was not unit-tested.