### PR TITLE
Renamed `enb.BuildFlow` to `enb.buildFlow`

### DIFF
--- a/lib/api/index.js
+++ b/lib/api/index.js
@@ -2,7 +2,7 @@ module.exports = {
     make: require('./make'),
     runServer: require('./run-server'),
     BaseTech: require('../tech/base-tech'),
-    BuildFlow: require('../build-flow'),
     FileList: require('../file-list'),
+    buildFlow: require('../build-flow'),
     asyncFs: require('../fs/async-fs')
 };


### PR DESCRIPTION
Resovled #404 