### PR TITLE
Fix absolute paths resolving in Node.resolvePath

### DIFF
--- a/lib/node/node.js
+++ b/lib/node/node.js
@@ -229,7 +229,7 @@ module.exports = inherit(/** @lends Node.prototype */ {
      * @returns {String}
      */
     resolvePath: function (filename) {
-        return this._dirname + path.sep + filename;
+        return path.resolve(this._dirname, filename);
     },
 
     /**

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "jscs": "2.8.0",
     "jshint": "2.9.1",
     "mocha": "2.3.4",
-    "mock-enb": "0.3.0",
+    "mock-enb": "0.3.1",
     "mock-fs": "3.6.0",
     "sinon": "1.16.1",
     "sinon-chai": "2.8.0"

--- a/test/techs/file-provider.test.js
+++ b/test/techs/file-provider.test.js
@@ -11,7 +11,8 @@ describe('techs/file-provider', function () {
         mockFS({
             bundle: {
                 'file.txt': 'I\'m here'
-            }
+            },
+            '/absolute.txt': 'You\'re here'
         });
 
         bundle = new MockNode('bundle');
@@ -28,6 +29,14 @@ describe('techs/file-provider', function () {
             .should.be.fulfilled
             .then(function () {
                 resolveSpy.should.calledWith('file.txt');
+            });
+    });
+
+    it('should provide file to target with absolute path', function () {
+        return bundle.runTech(FileProviderTech, { target: '/absolute.txt' })
+            .should.be.fulfilled
+            .then(function () {
+                resolveSpy.should.calledWith('/absolute.txt');
             });
     });
 


### PR DESCRIPTION
This change needed to allow `file-provider` tech work with absolute paths.

I'm not sure should it be like this or via `path.resolve`. Personally I prefer the last one.