### PR TITLE
What's the point to use CommonJS format in Cache files?

### DIFF
--- a/lib/cache/cache-storage.js
+++ b/lib/cache/cache-storage.js
@@ -3,7 +3,6 @@
  * ============
  */
 var fs = require('fs');
-var clearRequire = require('clear-require');
 var vow = require('vow');
 var inherit = require('inherit');
 
@@ -29,9 +28,8 @@ var CacheStorage = inherit(/** @lends CacheStorage.prototype */ {
      */
     load: function () {
         if (fs.existsSync(this._filename)) {
-            clearRequire(this._filename);
             try {
-                this._data = require(this._filename);
+                this._data = JSON.parse(fs.readFileSync(this._filename, 'utf8'));
             } catch (e) {
                 this._data = {};
             }
@@ -45,7 +43,7 @@ var CacheStorage = inherit(/** @lends CacheStorage.prototype */ {
      * Сохраняет кэш в файл.
      */
     save: function () {
-        fs.writeFileSync(this._filename, 'module.exports = ' + JSON.stringify(this._data) + ';', 'utf8');
+        fs.writeFileSync(this._filename, JSON.stringify(this._data), 'utf8');
         this._mtime = fs.statSync(this._filename).mtime.getTime();
     },
 
@@ -64,7 +62,7 @@ var CacheStorage = inherit(/** @lends CacheStorage.prototype */ {
 
             // Делаем stringify() на каждый объект в кеше чтобы уменьшить потребление памяти -
             // stringify() на больших кешах может отъедать сотни МБ.
-            stream.write('module.exports = {');
+            stream.write('{');
 
             prefixes.forEach(function (prefix, idx) {
                 stream.write('"' + prefix + '":');
@@ -74,7 +72,7 @@ var CacheStorage = inherit(/** @lends CacheStorage.prototype */ {
                 }
             });
 
-            stream.end('};', function () {
+            stream.end('}', function () {
                 _this._mtime = fs.statSync(_this._filename).mtime.getTime();
                 return resolve();
             });

--- a/lib/make.js
+++ b/lib/make.js
@@ -116,7 +116,7 @@ module.exports = inherit(/** @lends MakePlatform.prototype */ {
         var tmpDir = path.join(configDir, 'tmp');
 
         return vowFs.makeDir(tmpDir).then(function () {
-            _this._cacheStorage = new CacheStorage(path.join(tmpDir, 'cache.js'));
+            _this._cacheStorage = new CacheStorage(path.join(tmpDir, 'cache.json'));
             _this._nodes = {};
         });
     },

--- a/test/lib/make/init.js
+++ b/test/lib/make/init.js
@@ -215,7 +215,7 @@ describe('make/init', function () {
         it('should instantiate cache storage with path to cache file located in temp dir', function () {
             return init_({ projectPath: '/path/to/project' }).then(function () {
                 expect(makePlatform.getCacheStorage())
-                    .to.be.deep.equal(new CacheStorage(path.normalize('/path/to/project/.enb/tmp/cache.js')));
+                    .to.be.deep.equal(new CacheStorage(path.normalize('/path/to/project/.enb/tmp/cache.json')));
             });
         });
     });


### PR DESCRIPTION
This PR changes load/save logic in CacheStorage.
Now it uses JSON.parse+fs.readFileSync instead of require+clearRequire.

/cc @blond